### PR TITLE
accessibility fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,9 +46,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Liam</h2>
       <h3>
-        <a href="https://twitter.com/LiamConroyH" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/liamchampton" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/liam-conroy-hampton/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/LiamConroyH" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Liam's Twitter profile button"/></a>
+          <a href="https://github.com/liamchampton" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Liam's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/liam-conroy-hampton/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Liam's LinkedIn profile button"/></a>
       </h3>
       <br />
       
@@ -71,9 +71,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Yamini</h2>
       <h3>
-        <a href="https://twitter.com/yaminigrao" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/YaminiRao" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/yamini-rao/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a> 
+        <a href="https://twitter.com/yaminigrao" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Yamini's Twitter profile button"/></a>
+          <a href="https://github.com/YaminiRao" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Yamini's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/yamini-rao/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Yamini's LinkedIn profile button"/></a> 
       </h3>
       <br />
 
@@ -96,9 +96,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Ross</h2>
       <h3>
-        <a href="https://twitter.com/rcruicks" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/ibmrcruicks" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/ross-cruickshank/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/rcruicks" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Ross's Twitter profile button"/></a>
+          <a href="https://github.com/ibmrcruicks" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Ross's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/ross-cruickshank/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Ross's LinkedIn profile button"/></a>
       </h3>
       <br />
       <div class ="post">
@@ -118,9 +118,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Ed</h2>
       <h3>
-        <a href="https://twitter.com/ukcloudman" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/edshee" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/edshee/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/ukcloudman" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Ed's Twitter profile button"/></a>
+          <a href="https://github.com/edshee" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Ed's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/edshee/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Ed's LinkedIn profile button"/></a>
       </h3>
       <br />
       <div class = "post">
@@ -138,9 +138,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Sean</h2>
       <h3>
-        <a href="https://twitter.com/seanmtraceyH" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-        <a href="https://github.com/seanmtracey/" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-          <a href="https://www.linkedin.com/in/seanmtracey/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/seanmtraceyH" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Seans's Twitter profile button"/></a>
+        <a href="https://github.com/seanmtracey/" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Sean's GitHub profile button"/></a>
+          <a href="https://www.linkedin.com/in/seanmtracey/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Sean's LinkedIn profile button"/></a>
       </h3>
       <br />
       <div class = "post">
@@ -158,9 +158,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Margriet</h2>
       <h3>
-        <a href="https://twitter.com/MargrietGr" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/MargrietGroenendijk" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/margrietgroenendijk/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/MargrietGr" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Margriet's Twitter profile button"/></a>
+          <a href="https://github.com/MargrietGroenendijk" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Margriet's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/margrietgroenendijk/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Margriet's LinkedIn profile button"/></a>
       </h3>
       <br />
       <div class = "post">
@@ -179,9 +179,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Matt</h2>
       <h3>
-        <a href="https://twitter.com/HammerToe" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/hammertoe" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/matthamilton77/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/HammerToe" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Matt's Twitter profile button"/></a>
+          <a href="https://github.com/hammertoe" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Matt's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/matthamilton77/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Matt's LinkedIn profile button"/></a>
       </h3>
       <br/>
       <div class = "post">
@@ -198,9 +198,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Simon</h2>
       <h3>
-        <a href="https://twitter.com/SimonARBaker" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/SimonARBaker" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/simonarbaker/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/SimonARBaker" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Simon's Twitter profile button"/></a>
+          <a href="https://github.com/SimonARBaker" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Simon's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/simonarbaker/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Simon's LinkedIn profile button"/></a>
       </h3>
       <br />
       <div class = "post">
@@ -220,9 +220,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Andrea</h2>
       <h3>
-        <a href="https://twitter.com/blackchip76" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/afrittoli" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/andreafrittoli/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/blackchip76" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Andrea's Twitter profile button"/></a>
+          <a href="https://github.com/afrittoli" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Andrea's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/andreafrittoli/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Andrea's LinkedIn profile button"/></a>
         </a>
       </h3>
       <br />
@@ -241,9 +241,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Angela</h2>
       <h3>
-        <a href="https://twitter.com/angelajbates" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/IBMDeveloperUK" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/angelajbates/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/angelajbates" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Angela's Twitter profile button"/></a>
+          <a href="https://github.com/IBMDeveloperUK" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Angela's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/angelajbates/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Angela's LinkedIn profile button"/></a>
       </h3>
       <br />
       <div class = "post">
@@ -261,9 +261,9 @@ url: https://ibmdeveloperuk.github.io/
       </div>
       <h2>Mo</h2>
       <h3>
-        <a href="https://twitter.com/mohaghighi" class="social-button" target="_blank"><img src="assets/img/twitter.png" /></a>
-          <a href="https://github.com/mohaghighi" class="social-button" target="_blank"><img src="assets/img/github.png" /></a>
-            <a href="https://www.linkedin.com/in/mohaghighi/" class="social-button" target="_blank"><img src="assets/img/linkedin.png"/></a>
+        <a href="https://twitter.com/mohaghighi" class="social-button" target="_blank"><img src="assets/img/twitter.png" alt="Mo's Twitter profile button"/></a>
+          <a href="https://github.com/mohaghighi" class="social-button" target="_blank"><img src="assets/img/github.png" alt="Mo's GitHub profile button"/></a>
+            <a href="https://www.linkedin.com/in/mohaghighi/" class="social-button" target="_blank"><img src="assets/img/linkedin.png" alt="Mo's LinkedIn profile button"/></a>
       </h3>
       <br />
       <div class = "post">

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ url: https://ibmdeveloperuk.github.io/
 
     <div class="media">
     <div class="team-member-col">
-      <div class="team-member-liam team-member" title="Picture of Liam">
+      <div class="team-member-liam team-member" title="Picture of Liam and his tech stack">
         <span>Golang | Open Source</span>
       </div>
       <h2>Liam</h2>
@@ -66,7 +66,7 @@ url: https://ibmdeveloperuk.github.io/
   
 
     <div class="team-member-col">
-      <div class="team-member-yamini team-member" title="Picture of Yamini">
+      <div class="team-member-yamini team-member" title="Picture of Yamini her tech stack">
         <span>Data Science | Node-RED | Watson API's</span>
       </div>
       <h2>Yamini</h2>
@@ -91,7 +91,7 @@ url: https://ibmdeveloperuk.github.io/
 
 
     <div class="team-member-col">
-      <div class="team-member-ross team-member" title="Picture of Ross">
+      <div class="team-member-ross team-member" title="Picture of Ross his tech stack">
         <span>IOT | Node-RED | R</span>
       </div>
       <h2>Ross</h2>
@@ -113,7 +113,7 @@ url: https://ibmdeveloperuk.github.io/
 
 
     <div class="team-member-col">
-      <div class="team-member-ed team-member" title="Picture of Ed">
+      <div class="team-member-ed team-member" title="Picture of Ed his tech stack">
         <span>Cloud and Containers</span>
       </div>
       <h2>Ed</h2>
@@ -133,7 +133,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-sean team-member" title="Picture of Sean">
+      <div class="team-member-sean team-member" title="Picture of Sean his tech stack">
         <span>Artificial Intelligence | IOT | Node-RED | Python</span>
       </div>
       <h2>Sean</h2>
@@ -153,7 +153,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-margriet team-member" title="Picture of Margriet">
+      <div class="team-member-margriet team-member" title="Picture of Margriet her tech stack">
         <span>Data Science | Deep Learning |Python </span>
       </div>
       <h2>Margriet</h2>
@@ -174,7 +174,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-matt team-member" title="Picture of Matt">
+      <div class="team-member-matt team-member" title="Picture of Matt his tech stack">
         <span>Blockchain | Machine Learning | Data Science</span>
       </div>
       <h2>Matt</h2>
@@ -193,7 +193,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Simon team-member" title="Picture of Simon">
+      <div class="team-member-Simon team-member" title="Picture of Simon his team role">
         <span>Integrated Accounts</span>
       </div>
       <h2>Simon</h2>
@@ -215,7 +215,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Andrea team-member" title="Picture of Andrea">
+      <div class="team-member-Andrea team-member" title="Picture of Andrea his tech stack">
         <span>Containers | Serverless</span>
       </div>
       <h2>Andrea</h2>
@@ -236,7 +236,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Angela team-member" title="Picture of Angela">
+      <div class="team-member-Angela team-member" title="Picture of Angela and her team role">
         <span>Programme Manager</span>
       </div>
       <h2>Angela</h2>
@@ -256,7 +256,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Mo team-member" title="Picture of Mo">
+      <div class="team-member-Mo team-member" title="Picture of Mo his team role">
         <span>Head of Developer Advocacy (Europe)</span>
       </div>
       <h2>Mo</h2>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ url: https://ibmdeveloperuk.github.io/
 
     <div class="media">
     <div class="team-member-col">
-      <div class="team-member-liam team-member">
+      <div class="team-member-liam team-member" title="Picture of Liam">
         <span>Golang | Open Source</span>
       </div>
       <h2>Liam</h2>
@@ -66,7 +66,7 @@ url: https://ibmdeveloperuk.github.io/
   
 
     <div class="team-member-col">
-      <div class="team-member-yamini team-member">
+      <div class="team-member-yamini team-member" title="Picture of Yamini">
         <span>Data Science | Node-RED | Watson API's</span>
       </div>
       <h2>Yamini</h2>
@@ -91,7 +91,7 @@ url: https://ibmdeveloperuk.github.io/
 
 
     <div class="team-member-col">
-      <div class="team-member-ross team-member">
+      <div class="team-member-ross team-member" title="Picture of Ross">
         <span>IOT | Node-RED | R</span>
       </div>
       <h2>Ross</h2>
@@ -113,7 +113,7 @@ url: https://ibmdeveloperuk.github.io/
 
 
     <div class="team-member-col">
-      <div class="team-member-ed team-member">
+      <div class="team-member-ed team-member" title="Picture of Ed">
         <span>Cloud and Containers</span>
       </div>
       <h2>Ed</h2>
@@ -133,7 +133,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-sean team-member">
+      <div class="team-member-sean team-member" title="Picture of Sean">
         <span>Artificial Intelligence | IOT | Node-RED | Python</span>
       </div>
       <h2>Sean</h2>
@@ -153,7 +153,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-margriet team-member">
+      <div class="team-member-margriet team-member" title="Picture of Margriet">
         <span>Data Science | Deep Learning |Python </span>
       </div>
       <h2>Margriet</h2>
@@ -174,7 +174,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-matt team-member">
+      <div class="team-member-matt team-member" title="Picture of Matt">
         <span>Blockchain | Machine Learning | Data Science</span>
       </div>
       <h2>Matt</h2>
@@ -193,7 +193,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Simon team-member">
+      <div class="team-member-Simon team-member" title="Picture of Simon">
         <span>Integrated Accounts</span>
       </div>
       <h2>Simon</h2>
@@ -215,7 +215,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Andrea team-member">
+      <div class="team-member-Andrea team-member" title="Picture of Andrea">
         <span>Containers | Serverless</span>
       </div>
       <h2>Andrea</h2>
@@ -236,7 +236,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Angela team-member">
+      <div class="team-member-Angela team-member" title="Picture of Angela">
         <span>Programme Manager</span>
       </div>
       <h2>Angela</h2>
@@ -256,7 +256,7 @@ url: https://ibmdeveloperuk.github.io/
     </div>
 
     <div class="team-member-col">
-      <div class="team-member-Mo team-member">
+      <div class="team-member-Mo team-member" title="Picture of Mo">
         <span>Head of Developer Advocacy (Europe)</span>
       </div>
       <h2>Mo</h2>


### PR DESCRIPTION
fixes #32 
- Add alt tags to social icon images
<img width="280" alt="Screenshot 2020-10-06 at 12 19 52" src="https://user-images.githubusercontent.com/42477259/95195332-48256600-07ce-11eb-89cf-2a6411ee92ba.png">
